### PR TITLE
Fix RETTR status bits.

### DIFF
--- a/pep9asm/isacpu.cpp
+++ b/pep9asm/isacpu.cpp
@@ -632,6 +632,7 @@ bool IsaCpu::writeOperandByte(quint16 operand, quint8 value, Enu::EAddrMode addr
 void IsaCpu::executeUnary(Enu::EMnemonic mnemon)
 {
     quint16 temp, sp, acc, idx;
+    quint8 tempByte;
     sp = registerBank.readRegisterWordCurrent(Enu::CPURegisters::SP);
     acc = registerBank.readRegisterWordCurrent(Enu::CPURegisters::A);
     idx = registerBank.readRegisterWordCurrent(Enu::CPURegisters::X);
@@ -649,9 +650,9 @@ void IsaCpu::executeUnary(Enu::EMnemonic mnemon)
         break;
 
     case Enu::EMnemonic::RETTR:
-        memory->readWord(sp, temp);
+        memory->readByte(sp, tempByte);
         // Function will automatically mask out bits that don't matter
-        registerBank.writeStatusBits(static_cast<quint8>(temp));
+        registerBank.writeStatusBits(tempByte);
         memory->readWord(sp + 1, temp);
         registerBank.writeRegisterWord(Enu::CPURegisters::A, temp);
         memory->readWord(sp + 3, temp);


### PR DESCRIPTION
Fix bug where NZVCS are improperly restored when the system stack is even-aligned.

I fixed this bug in Pep10, but have not had a chance to regression test Pep9. I created this fix via the online editor so  I do not know that it will fix Pep9 for certain.